### PR TITLE
Update rules for contribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,23 +6,22 @@ A list of resources connected to the [SpaceTraders API](https://spacetraders.io/
 
 ## Contents
 
-- [Awesome SpaceTraders](#awesome-spacetraders)
-  - [Contents](#contents)
-  - [Client](#client)
-  - [SDKs](#sdks)
-  - [Assets](#assets)
-  - [Tutorials](#tutorials)
+* [Awesome SpaceTraders](#awesome-spacetraders)
+  * [Contents](#contents)
+  * [Client](#client)
+  * [SDKs](#sdks)
+  * [Assets](#assets)
+  * [Tutorials](#tutorials)
 
 ## Client
+
 * [Deliverance](https://github.com/Stumblinbear/Deliverance) - VueJS-based web interface for Space Traders.
-
 * [TradeCommander](https://github.com/DotEfekts/TradeCommander/) - A browser-based CLI style interface written in Blazor WebAssembly.
-
 * [Trade Warriors](https://thaurin.github.io/trade-warriors/) - Trade Warriors is a frontend for the Space Traders API, written in Vue 3.
 
 ## SDKs
-- [space_trader](https://github.com/HOWZ1T/space_trader) - An Golang api wrapper with internal caching and an event system.
 
+* [space_trader](https://github.com/HOWZ1T/space_trader) - An Golang api wrapper with internal caching and an event system.
 * [SpaceMongers](https://github.com/ericgroom/space_mongers) - Elixir API wrapper with integrated rate limiting.
 
 ## Assets

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A list of resources connected to the [SpaceTraders API](https://spacetraders.io/
 
 * [Deliverance](https://github.com/Stumblinbear/Deliverance) - VueJS-based web interface for Space Traders.
 * [TradeCommander](https://github.com/DotEfekts/TradeCommander/) - A browser-based CLI style interface written in Blazor WebAssembly.
-* [Trade Warriors](https://thaurin.github.io/trade-warriors/) - Trade Warriors is a frontend for the Space Traders API, written in Vue 3.
+* [Trade Warriors](https://github.com/thaurin/trade-warriors) - Trade Warriors is a frontend for the Space Traders API, written in Vue 3.
 
 ## SDKs
 

--- a/contributing.md
+++ b/contributing.md
@@ -3,24 +3,30 @@
 Make sure that any pull request you make adhere to the following guidelines:
 
 - There are no previous suggestions already made for your addition.
-- Use the following format: [List Name](link) - Short description.
+- Pull requests adding new items should have the title: Add [Name]
+- Pull requests removing items should have the title: Remove [Name]
+- Use the following format: [Name](link) - Short description.
   - The short description has a **hard limit** on 150 characters. Shorter than maximum is advised.
   - The short description ends with a period.
+  - The `*` character is used for the markdown list.
 - Links should be added alphabetically to the relevant category.
+- Only a *single line* is used for the added item.
+- There are no empty rows between items of a list.
 - New categories or improvements to the existing categorization are welcome.
   - At least 3 items are needed to create a new category.
+  - Blank lines should come directly before and after a header.
 - Check your spelling and grammar.
 - Make sure your text editor is set to remove trailing whitespace.
-- The pull request and commit should have a useful title.
 
 ## Quality standards
 
-There are different quality standards required for different categories
+There are different quality standards required for different categories.
 
 ### Code
 
 - The referenced software is well documented and includes instructions on how to use it.
 - The referenced software is actively maintained.
+- The link must point to the source code.
 
 ## Reporting issues
 


### PR DESCRIPTION
I've noticed there are things not specified in the [contributing.md](https://github.com/SpaceTradersAPI/awesome-spacetraders/blob/main/contributing.md) file causing the pull requests to cause inconsistencies in the list. Do you feel the rules I added are too strict? Should something be changed? Anyone is welcome to give advice! Specifically I'd like @artokun to look through the changes as he's merged a few PRs.

In addition, one change affects Trade Warriors entry which links to the hosted site and not the source code. My reasoning for preferring the source code is since it most likely already points to a hosted version should one exist. It's also likely that most people looking through this list is mainly interested in source code. Note that this is my thoughts and I should not alone make decisions. Should the rule be accepted would @Thaurin mind if we changed the link to point to your GitHub page for the project instead?