### PR TITLE
Add spacetraders-sdk by @notvitaliy

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ A list of resources connected to the [SpaceTraders API](https://spacetraders.io/
 
 * [space_trader](https://github.com/HOWZ1T/space_trader) - An Golang api wrapper with internal caching and an event system.
 * [SpaceMongers](https://github.com/ericgroom/space_mongers) - Elixir API wrapper with integrated rate limiting.
-* [Spacetraders.io](https://github.com/notVitaliy/spacetraders-io) - A Javascript/Typescript SDK.
+* [spacetraders-sdk](https://github.com/notVitaliy/spacetraders-io) - A Javascript/Typescript SDK.
 
 ## Assets
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ A list of resources connected to the [SpaceTraders API](https://spacetraders.io/
 
 * [space_trader](https://github.com/HOWZ1T/space_trader) - An Golang api wrapper with internal caching and an event system.
 * [SpaceMongers](https://github.com/ericgroom/space_mongers) - Elixir API wrapper with integrated rate limiting.
-* [Spacetraders.io](https://github.com/notVitaliy/spacetraders-io) - A Javascript/Typescript SDK
+* [Spacetraders.io](https://github.com/notVitaliy/spacetraders-io) - A Javascript/Typescript SDK.
 
 ## Assets
 

--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@ A list of resources connected to the [SpaceTraders API](https://spacetraders.io/
 
 ## Contents
 
-* [Awesome SpaceTraders](#awesome-spacetraders)
-  * [Contents](#contents)
-  * [Client](#client)
-  * [SDKs](#sdks)
-  * [Assets](#assets)
-  * [Tutorials](#tutorials)
+- [Awesome SpaceTraders](#awesome-spacetraders)
+  - [Contents](#contents)
+  - [Client](#client)
+  - [SDKs](#sdks)
+  - [Assets](#assets)
+  - [Tutorials](#tutorials)
 
 ## Client
 
@@ -23,6 +23,7 @@ A list of resources connected to the [SpaceTraders API](https://spacetraders.io/
 
 * [space_trader](https://github.com/HOWZ1T/space_trader) - An Golang api wrapper with internal caching and an event system.
 * [SpaceMongers](https://github.com/ericgroom/space_mongers) - Elixir API wrapper with integrated rate limiting.
+* [Spacetraders.io](https://github.com/notVitaliy/spacetraders-io) - A Javascript/Typescript SDK
 
 ## Assets
 

--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@ A list of resources connected to the [SpaceTraders API](https://spacetraders.io/
 
 ## Contents
 
-- [Awesome SpaceTraders](#awesome-spacetraders)
-  - [Contents](#contents)
-  - [Client](#client)
-  - [SDKs](#sdks)
-  - [Assets](#assets)
-  - [Tutorials](#tutorials)
+* [Awesome SpaceTraders](#awesome-spacetraders)
+  * [Contents](#contents)
+  * [Client](#client)
+  * [SDKs](#sdks)
+  * [Assets](#assets)
+  * [Tutorials](#tutorials)
 
 ## Client
 


### PR DESCRIPTION
This PR adds the spacetraders.io SDK for Javascript/Typescript to the list under the SDK category.
