### PR TITLE
Add Erebos Space Traders UI web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ A list of resources connected to the [SpaceTraders API](https://spacetraders.io/
 ## Client
 
 * [Deliverance](https://github.com/Stumblinbear/Deliverance) - VueJS-based web interface for Space Traders.
+* [Erebos](https://github.com/Kaishiyoku/erebos) - React-based web application for Space Traders.
 * [TradeCommander](https://github.com/DotEfekts/TradeCommander/) - A browser-based CLI style interface written in Blazor WebAssembly.
 * [Trade Warriors](https://github.com/thaurin/trade-warriors) - Trade Warriors is a frontend for the Space Traders API, written in Vue 3.
 


### PR DESCRIPTION
This PR adds the Erebos web client to the readme. The client currently is at an early stage of development.