### PR TITLE
Add MerchantExpanse

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ A list of resources connected to the [SpaceTraders API](https://spacetraders.io/
 
 ## SDKs
 
+* [MerchantExpanse](https://github.com/Oronar/MerchantExpanse) - A .NET 5 API wrapper.
 * [space_trader](https://github.com/HOWZ1T/space_trader) - An Golang api wrapper with internal caching and an event system.
 * [SpaceMongers](https://github.com/ericgroom/space_mongers) - Elixir API wrapper with integrated rate limiting.
 * [spacetraders-sdk](https://github.com/notVitaliy/spacetraders-io) - A Javascript/Typescript SDK.


### PR DESCRIPTION
[MerchantExpanse](https://github.com/Oronar/MerchantExpanse) is a .NET 5 API wrapper. The repo now contains some instructions on how to install the nuget package and a basic example project to demonstrate its use.