### PR TITLE
Add manufacturer logos

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ A list of resources connected to the [SpaceTraders API](https://spacetraders.io/
 * [SpaceTradersPHP](https://github.com/rayblair06/SpaceTradersPHP) - A PHP Api Wrapper.
 
 ## Assets
+
 * [Manufacturer Logos](https://github.com/bknyn/spacetraders-manufacturers-logos) - SVG logos for ship manufacturers
 
 ## Tutorials

--- a/README.md
+++ b/README.md
@@ -30,5 +30,6 @@ A list of resources connected to the [SpaceTraders API](https://spacetraders.io/
 * [SpaceTradersPHP](https://github.com/rayblair06/SpaceTradersPHP) - A PHP Api Wrapper.
 
 ## Assets
+* [Manufacturer Logos](https://github.com/bknyn/spacetraders-manufacturers-logos) - SVG logos for ship manufacturers
 
 ## Tutorials


### PR DESCRIPTION
This PR:
- Adds link for bknyn's manufacturer logos to `assets` section of readme